### PR TITLE
Undefined name 'file_path' In FTP_controller.py

### DIFF
--- a/FTP_controller.py
+++ b/FTP_controller.py
@@ -177,7 +177,7 @@ class ftp_controller:
         try:
             file_to_up = open(file_name, 'rb')
         except:
-            status_command(file_path, 'Failed to open file')
+            status_command(file_name, 'Failed to open file')
             return
        #Try to upload file
         try:


### PR DESCRIPTION
https://github.com/RainingComputers/whipFTP/search?q=file_path&unscoped_q=file_path

flake8 testing of https://github.com/RainingComputers/whipFTP on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./FTP_controller.py:180:28: F821 undefined name 'file_path'
            status_command(file_path, 'Failed to open file')
                           ^
1     F821 undefined name 'file_path'
1
```